### PR TITLE
Add AttributedSpans and AttributedText to the package

### DIFF
--- a/example/lib/demo_attributed_text.dart
+++ b/example/lib/demo_attributed_text.dart
@@ -255,11 +255,6 @@ class _TextRangeSelectorState extends State<TextRangeSelector> {
       ranges.add(TextRange(start: rangeStart, end: widget.cellCount - 1));
     }
 
-    print('Reporting ranges:');
-    for (final range in ranges) {
-      print(' - $range');
-    }
-
     widget.onRangesChange(ranges);
   }
 

--- a/example/lib/demo_attributed_text.dart
+++ b/example/lib/demo_attributed_text.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/material.dart' hide SelectableText;
+import 'package:flutter_richtext/flutter_richtext.dart';
+
+class AttributedTextDemo extends StatefulWidget {
+  @override
+  _AttributedTextDemoState createState() => _AttributedTextDemoState();
+}
+
+class _AttributedTextDemoState extends State<AttributedTextDemo> {
+  final List<TextRange> _boldRanges = [];
+  final List<TextRange> _italicsRanges = [];
+  final List<TextRange> _strikethroughRanges = [];
+  TextSpan _richText;
+  String _plainText;
+
+  @override
+  void initState() {
+    super.initState();
+    _computeStyledText();
+  }
+
+  void _computeStyledText() {
+    AttributedText _text = AttributedText(
+      text: 'This is some text styled with AttributedText',
+    );
+
+    for (final range in _boldRanges) {
+      _text.addAttribution('bold', range);
+    }
+    for (final range in _italicsRanges) {
+      _text.addAttribution('italics', range);
+    }
+    for (final range in _strikethroughRanges) {
+      _text.addAttribution('strikethrough', range);
+    }
+
+    setState(() {
+      _richText = _text.computeTextSpan((Set<dynamic> attributions) {
+        TextStyle newStyle = const TextStyle(
+          color: Colors.black,
+          fontSize: 30,
+        );
+        for (final attribution in attributions) {
+          if (attribution is! String) {
+            continue;
+          }
+
+          switch (attribution) {
+            case 'bold':
+              newStyle = newStyle.copyWith(
+                fontWeight: FontWeight.bold,
+              );
+              break;
+            case 'italics':
+              newStyle = newStyle.copyWith(
+                fontStyle: FontStyle.italic,
+              );
+              break;
+            case 'strikethrough':
+              newStyle = newStyle.copyWith(
+                decoration: TextDecoration.lineThrough,
+              );
+              break;
+          }
+        }
+        return newStyle;
+      });
+      _plainText = _richText.toPlainText();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 20.0),
+            child: Text(
+              'AttributedText',
+              style: TextStyle(
+                color: const Color(0xFF888888),
+                fontSize: 32,
+              ),
+            ),
+          ),
+          SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.only(left: 20.0),
+            child: Text(
+              '''AttributedText is a data structure that supports an arbitrary number of 
+"attribution spans". These attributions can be anything, and mean anything.
+
+AttributedText easily facilitates the creation of a TextSpan based on its attributions. 
+That TextSpan can then be rendered by Flutter, as usual.
+
+Try it yourself by adding and removing attributions to characters in a string...''',
+              style: TextStyle(
+                color: const Color(0xFF888888),
+                fontSize: 14,
+                height: 1.4,
+                fontWeight: FontWeight.normal,
+              ),
+            ),
+          ),
+          SizedBox(height: 24),
+          SizedBox(
+            width: 600,
+            child: Divider(),
+          ),
+          SizedBox(height: 24),
+          Table(
+            defaultColumnWidth: IntrinsicColumnWidth(),
+            defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+            children: [
+              TableRow(
+                children: [
+                  _buildRowTitle('Bold'),
+                  _buildCellSelector(_boldRanges),
+                ],
+              ),
+              TableRow(
+                children: [
+                  _buildRowTitle('Italics'),
+                  _buildCellSelector(_italicsRanges),
+                ],
+              ),
+              TableRow(
+                children: [
+                  _buildRowTitle('Strikethrough'),
+                  _buildCellSelector(_strikethroughRanges),
+                ],
+              ),
+              TableRow(
+                children: [
+                  SizedBox(height: 24),
+                  SizedBox(height: 24),
+                ],
+              ),
+              TableRow(
+                children: [
+                  _buildRowTitle('Attributed Text'),
+                  SelectableText(
+                    key: GlobalKey(),
+                    textSpan: _richText ?? TextSpan(text: 'error'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRowTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+      child: Text(title),
+    );
+  }
+
+  Widget _buildCellSelector(List<TextRange> rangesToUpdate) {
+    return TextRangeSelector(
+      cellCount: _plainText.length,
+      cellWidth: 11,
+      cellHeight: 20,
+      onRangesChange: (newRanges) {
+        rangesToUpdate
+          ..clear()
+          ..addAll(newRanges);
+        _computeStyledText();
+      },
+    );
+  }
+}
+
+class TextRangeSelector extends StatefulWidget {
+  const TextRangeSelector({
+    Key key,
+    @required this.cellCount,
+    this.cellWidth = 10,
+    this.cellHeight = 10,
+    this.onRangesChange,
+  }) : super(key: key);
+
+  final int cellCount;
+  final double cellWidth;
+  final double cellHeight;
+  final void Function(List<TextRange>) onRangesChange;
+
+  @override
+  _TextRangeSelectorState createState() => _TextRangeSelectorState();
+}
+
+class _TextRangeSelectorState extends State<TextRangeSelector> {
+  List<bool> _selectedCells;
+  String _selectionMode;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedCells = List.filled(widget.cellCount, false);
+  }
+
+  bool _isSelected(int index) {
+    return _selectedCells[index];
+  }
+
+  void _onTapUp(TapUpDetails details) {
+    final selectedCellIndex = _getCellIndexFromLocalOffset(details.localPosition);
+    setState(() {
+      _selectedCells[selectedCellIndex] = !_selectedCells[selectedCellIndex];
+      _reportSelectedRanges();
+    });
+  }
+
+  void _onPanStart(DragStartDetails details) {
+    final selectedCellIndex = _getCellIndexFromLocalOffset(details.localPosition);
+    _selectionMode = _selectedCells[selectedCellIndex] ? 'deselect' : 'select';
+  }
+
+  void _onPanUpdate(DragUpdateDetails details) {
+    final selectedCellIndex = _getCellIndexFromLocalOffset(details.localPosition);
+    setState(() {
+      _selectedCells[selectedCellIndex] = _selectionMode == 'select';
+      _reportSelectedRanges();
+    });
+  }
+
+  int _getCellIndexFromLocalOffset(Offset localOffset) {
+    return ((localOffset.dx / widget.cellWidth).floor()).clamp(0.0, widget.cellCount - 1).toInt();
+  }
+
+  void _reportSelectedRanges() {
+    if (widget.onRangesChange == null) {
+      return;
+    }
+
+    final ranges = <TextRange>[];
+    int rangeStart = -1;
+    for (int i = 0; i < _selectedCells.length; ++i) {
+      if (_selectedCells[i]) {
+        if (rangeStart < 0) {
+          rangeStart = i;
+        }
+      } else if (rangeStart >= 0) {
+        ranges.add(TextRange(start: rangeStart, end: i - 1));
+        rangeStart = -1;
+      }
+    }
+    if (rangeStart >= 0) {
+      ranges.add(TextRange(start: rangeStart, end: widget.cellCount - 1));
+    }
+
+    print('Reporting ranges:');
+    for (final range in ranges) {
+      print(' - $range');
+    }
+
+    widget.onRangesChange(ranges);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapUp: _onTapUp,
+      onPanStart: _onPanStart,
+      onPanUpdate: _onPanUpdate,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(
+          widget.cellCount,
+          (index) => Container(
+            width: widget.cellWidth,
+            height: widget.cellHeight,
+            decoration: BoxDecoration(
+              border: Border.all(width: 1, color: _isSelected(index) ? Colors.red : Colors.grey),
+              color: _isSelected(index) ? Colors.red.withOpacity(0.7) : Colors.grey.withOpacity(0.7),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:example/demo_selectable_text.dart';
 import 'package:example/example_editor.dart';
 import 'package:flutter/material.dart';
 
+import 'demo_attributed_text.dart';
+
 /// Demo of a basic text editor, as well as various widgets that
 /// are available in this package.
 Future<void> main() async {
@@ -139,6 +141,13 @@ final _menu = <_MenuGroup>[
           return SelectableTextDemo();
         },
       ),
+      _MenuItem(
+        icon: Icons.text_fields,
+        title: 'Attributed Text',
+        pageBuilder: (context) {
+          return AttributedTextDemo();
+        },
+      ),
     ],
   ),
 ];
@@ -220,12 +229,11 @@ class _DrawerButton extends StatelessWidget {
 
               return Colors.transparent;
             }),
-            splashFactory: NoSplash.splashFactory,
+            // splashFactory: NoSplash.splashFactory,
             foregroundColor:
                 MaterialStateColor.resolveWith((states) => isSelected ? Colors.white : const Color(0xFFBBBBBB)),
             elevation: MaterialStateProperty.resolveWith((states) => 0),
-            padding: MaterialStateProperty.resolveWith(
-                (states) => const EdgeInsets.all(16))),
+            padding: MaterialStateProperty.resolveWith((states) => const EdgeInsets.all(16))),
         onPressed: isSelected ? null : onPressed,
         child: Row(
           children: [

--- a/lib/flutter_richtext.dart
+++ b/lib/flutter_richtext.dart
@@ -1,3 +1,5 @@
 library flutter_richtext;
 
 export 'src/infrastructure/selectable_text.dart';
+export 'src/infrastructure/attributed_text.dart';
+export 'src/infrastructure/attributed_spans.dart';

--- a/lib/src/infrastructure/_logging.dart
+++ b/lib/src/infrastructure/_logging.dart
@@ -1,0 +1,23 @@
+class Logger {
+  static bool _printLogs = false;
+  static void setLoggingMode(bool enabled) {
+    _printLogs = enabled;
+  }
+
+  Logger({
+    required scope,
+  }) : _scope = scope;
+
+  final String _scope;
+
+  void log(String tag, String message, [Exception? exception]) {
+    if (!Logger._printLogs) {
+      return;
+    }
+
+    print('[$_scope] - $tag: $message');
+    if (exception != null) {
+      print(' - ${exception.toString()}');
+    }
+  }
+}

--- a/lib/src/infrastructure/attributed_spans.dart
+++ b/lib/src/infrastructure/attributed_spans.dart
@@ -1,0 +1,817 @@
+import 'package:collection/collection.dart';
+
+/// A set of spans, each with an associated attribution, that take
+/// up some amount of space in a discrete range. `AttributedSpans`
+/// are useful when implementing attributed text for the purpose
+/// of markup and styling.
+///
+/// You can think of `AttributedSpans` like a set of lanes. Each
+/// lane may be occupied by some series of spans for a particular
+/// attribute:
+///
+/// ------------------------------------------------------
+/// Bold    :  {xxxx}                      {xxxxx}
+/// Italics :             {xxxxxxxx}
+/// Link    :                              {xxxxx}
+/// ------------------------------------------------------
+///
+/// The name of an attribution of a span can hold any value of any type.
+/// For text styling, a client might choose `String` values like
+/// 'bold' and 'italics'.
+///
+/// Each attributed span is represented by two `SpanMarker`s, one
+/// with type `SpanMarkerType.start` and one with type
+/// `SpanMarkerType.end`.
+///
+/// Spans with the same attribution cannot overlap each other, but
+/// spans with different attributions can overlap each other.
+///
+/// When applying `AttributedSpans` to text as styles, you'll
+/// eventually want a collapsed series of spans. Use `collapseSpans()`
+/// to collapse the different attribution spans into a single
+/// series of multi-attribution spans.
+class AttributedSpans {
+  AttributedSpans({
+    int length = 0,
+    List<SpanMarker>? attributions,
+  })  : _length = length,
+        attributions = attributions ?? [] {
+    _ensureMarkersAreInOrder();
+  }
+
+  // Throws an exception if `attributions` are not in order from lowest
+  // index to highest index.
+  void _ensureMarkersAreInOrder() {
+    int previousOffset = -1;
+    for (final attribution in this.attributions) {
+      if (attribution.offset < previousOffset) {
+        // The attributions are not in order.
+        final attributionsDescription = attributions.join(', ');
+        throw Exception('The given attributions are not in the correct order: $attributionsDescription');
+      }
+      previousOffset = attribution.offset;
+    }
+  }
+
+  // TODO: length is a concept that came from AttributedText. Do we
+  //       even need to enforce a length in AttributedSpans?
+  // The length of the range that these spans are
+  // allowed to occupy.
+  final int _length;
+
+  // TODO: make attributions private, but ensure that tests are effective
+  final List<SpanMarker> attributions;
+
+  /// Returns true if this `AttributedSpans` contains at least one
+  /// unit of attribution for each of the given `attributions`
+  /// within the given range (inclusive).
+  bool hasAttributionsWithin({
+    required Set<dynamic> attributions,
+    required int start,
+    required int end,
+  }) {
+    final attributionsToFind = Set.from(attributions);
+    for (int i = start; i <= end; ++i) {
+      for (final attribution in attributionsToFind) {
+        if (hasAttributionAt(i, attribution: attribution)) {
+          attributionsToFind.remove(attribution);
+        }
+
+        if (attributionsToFind.isEmpty) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Returns true if a span with the given `attribution` covers the given
+  /// `offset`.
+  bool hasAttributionAt(
+    int offset, {
+    dynamic attribution,
+  }) {
+    SpanMarker? markerBefore = _getStartingMarkerAtOrBefore(offset, attribution: attribution);
+    if (markerBefore == null) {
+      // print(' - there is no start marker for "$attribution" before $offset');
+      return false;
+    }
+    SpanMarker? markerAfter = _getEndingMarkerAtOrAfter(markerBefore.offset, attribution: attribution);
+    if (markerAfter == null) {
+      throw Exception('Found an open-ended attribution. It starts with: $markerBefore');
+    }
+
+    // print('Looking for "$attribution" at $offset. Before: ${markerBefore.offset}, After: ${markerAfter.offset}');
+
+    return (markerBefore.offset <= offset) && (offset <= markerAfter.offset);
+  }
+
+  /// Returns all attributions for spans that cover the given `offset`.
+  Set<dynamic> getAllAttributionsAt(int offset) {
+    final allAttributions = <dynamic>{};
+    for (final marker in attributions) {
+      allAttributions.add(marker.attribution);
+    }
+
+    final attributionsAtOffset = <dynamic>{};
+    for (final attribution in allAttributions) {
+      final hasAttribution = hasAttributionAt(offset, attribution: attribution);
+      // print(' - has "$attribution" attribution at $offset? ${hasAttribution}');
+      if (hasAttribution) {
+        attributionsAtOffset.add(attribution);
+      }
+    }
+
+    return attributionsAtOffset;
+  }
+
+  SpanMarker? _getStartingMarkerAtOrBefore(int offset, {dynamic attribution}) {
+    return attributions //
+        .reversed // search from the end so its the nearest start marker
+        .where((marker) => attribution == null || marker.attribution == attribution)
+        .firstWhereOrNull((marker) => marker.isStart && marker.offset <= offset);
+  }
+
+  SpanMarker? _getEndingMarkerAtOrAfter(int offset, {dynamic attribution}) {
+    return attributions
+        .where((marker) => attribution == null || marker.attribution == attribution)
+        .firstWhereOrNull((marker) => marker.isEnd && marker.offset >= offset);
+  }
+
+  /// Adds a span with the given `newAttribution` from `start` to `end`,
+  /// inclusive, or expands existing spans to cover at least the range
+  /// between `start` and `end`.
+  void addAttribution({
+    required dynamic newAttribution,
+    required int start,
+    required int end,
+  }) {
+    if (start < 0 || start > end) {
+      return;
+    }
+    if (end >= _length) {
+      throw Exception(
+          'Attribution range exceeds AttributedSpans length. AttributedSpans length: $_length, given range: $start -> $end');
+    }
+
+    print('addAttribution(): $start -> $end');
+    if (!hasAttributionAt(start, attribution: newAttribution)) {
+      print(' - adding start marker at: $start');
+      _insertMarker(SpanMarker(
+        attribution: newAttribution,
+        offset: start,
+        markerType: SpanMarkerType.start,
+      ));
+    }
+
+    // Delete all matching attributions between `range.start`
+    // and `range.end`.
+    final markersToDelete = attributions
+        .where((attribution) => attribution.attribution == newAttribution)
+        .where((attribution) => attribution.offset > start)
+        .where((attribution) => attribution.offset <= end)
+        .toList();
+    print(' - removing ${markersToDelete.length} markers between $start and $end');
+    // TODO: ideally we'd say "remove all" but that method doesn't
+    //       seem to exist?
+    attributions.removeWhere((element) => markersToDelete.contains(element));
+
+    final lastDeletedMarker = markersToDelete.isNotEmpty ? markersToDelete.last : null;
+
+    if (lastDeletedMarker == null || lastDeletedMarker.markerType == SpanMarkerType.end) {
+      // If we didn't delete any markers, the span that began at
+      // `range.start` or before needs to be capped off.
+      //
+      // If we deleted some markers, but the last marker was an
+      // `end` marker, we still have an open-ended span and we
+      // need to cap it off.
+      print(' - inserting ending marker at: $end');
+      _insertMarker(SpanMarker(
+        attribution: newAttribution,
+        offset: end,
+        markerType: SpanMarkerType.end,
+      ));
+    }
+    // Else, `range.end` is in the middle of larger span and
+    // doesn't need to be inserted.
+
+    print(' - all attributions after:');
+    attributions.where((element) => element.attribution == newAttribution).forEach((element) {
+      print(' - $element');
+    });
+  }
+
+  /// Removes any matching attribution spans between `start` and
+  /// `end`, inclusive.
+  void removeAttribution({
+    required dynamic attributionToRemove,
+    required int start,
+    required int end,
+  }) {
+    if (start < 0 || start > end) {
+      return;
+    }
+    if (end >= _length) {
+      throw Exception('Attribution range exceeds AttributedSpans length.');
+    }
+
+    print('removeAttribution(): $start -> $end');
+    if (hasAttributionAt(start, attribution: attributionToRemove)) {
+      final markerAtStart = _getMarkerAt(attributionToRemove, start);
+
+      if (markerAtStart == null) {
+        print(' - inserting new `end` marker at start of range');
+        _insertMarker(SpanMarker(
+          attribution: attributionToRemove,
+          // Note: if `range.start` is zero, then markerAtStart
+          // must not be null, so this condition never triggers.
+          offset: start - 1,
+          markerType: SpanMarkerType.end,
+        ));
+      } else if (markerAtStart.isStart) {
+        print(' - removing a `start` marker at start of range');
+        _removeMarker(markerAtStart);
+      } else {
+        throw Exception(
+            '_hasAttributionAt() said there was an attribution for "$attributionToRemove" at offset "$start", but there is an `end` marker at that position.');
+      }
+    }
+
+    // Delete all matching attributions between `range.start`
+    // and `range.end`.
+    final markersToDelete = attributions
+        .where((attribution) => attribution.attribution == attributionToRemove)
+        .where((attribution) => attribution.offset > start)
+        .where((attribution) => attribution.offset <= end)
+        .toList();
+    print(' - removing ${markersToDelete.length} markers between $start and $end');
+    // TODO: ideally we'd say "remove all" but that method doesn't
+    //       seem to exist?
+    attributions.removeWhere((element) => markersToDelete.contains(element));
+
+    if (end >= _length - 1) {
+      // If the range ends at the end of the AttributedSpans, we don't
+      // need to insert any `start` markers because there can't be any
+      // other `end` markers later in the AttributedSpans.
+      print(' - this range goes to the end of the AttributedSpans, so we don\'t need to insert any more markers.');
+      print(' - all attributions after:');
+      attributions.where((element) => element.attribution == attributionToRemove).forEach((element) {
+        print(' - $element');
+      });
+      return;
+    }
+
+    final lastDeletedMarker = markersToDelete.isNotEmpty ? markersToDelete.last : null;
+
+    if (lastDeletedMarker == null || lastDeletedMarker.markerType == SpanMarkerType.start) {
+      // The last marker we deleted was a `start` marker.
+      // Therefore, an `end` marker appears somewhere down the line.
+      // We can't leave it dangling. Add a `start` marker back.
+      print(' - inserting a final `start` marker at the end to keep symmetry');
+      _insertMarker(SpanMarker(
+        attribution: attributionToRemove,
+        offset: end + 1,
+        markerType: SpanMarkerType.start,
+      ));
+    }
+
+    print(' - all attributions after:');
+    attributions.where((element) => element.attribution == attributionToRemove).forEach((element) {
+      print(' - $element');
+    });
+  }
+
+  /// If ALL of the units in `range` contain the given `attribution`,
+  /// that attribution is removed from those units. Otherwise, all of
+  /// the units in `range` are assigned the `attribution`.
+  void toggleAttribution({
+    required dynamic attribution,
+    required int start,
+    required int end,
+  }) {
+    if (_isContinuousAttribution(attribution: attribution, start: start, end: end)) {
+      removeAttribution(attributionToRemove: attribution, start: start, end: end);
+    } else {
+      addAttribution(newAttribution: attribution, start: start, end: end);
+    }
+  }
+
+  bool _isContinuousAttribution({
+    required dynamic attribution,
+    required int start,
+    required int end,
+  }) {
+    print('_isContinousAttribution(): "$attribution", range: $start -> $end');
+    SpanMarker? markerBefore = _getNearestMarkerAtOrBefore(start, attribution: attribution);
+    print(' - marker before: $markerBefore');
+
+    if (markerBefore == null || markerBefore.isEnd) {
+      return false;
+    }
+
+    final indexBefore = attributions.indexOf(markerBefore);
+    final nextMarker = attributions.sublist(indexBefore).firstWhereOrNull(
+          (marker) => marker.attribution == attribution && marker.offset > markerBefore.offset,
+        );
+    print(' - next marker: $nextMarker');
+
+    if (nextMarker == null) {
+      throw Exception('Inconsistent attributions state. Found a `start` marker with no matching `end`.');
+    }
+    if (nextMarker.isStart) {
+      throw Exception('Inconsistent attributions state. Found a `start` marker following a `start` marker.');
+    }
+
+    // If there is even one additional marker in the `range`
+    // of interest, it means that the given attribution is
+    // not applied to the entire range.
+    return nextMarker.offset >= end;
+  }
+
+  SpanMarker? _getNearestMarkerAtOrBefore(
+    int offset, {
+    dynamic attribution,
+  }) {
+    SpanMarker? markerBefore;
+    final markers =
+        attribution != null ? attributions.where((marker) => marker.attribution == attribution) : attributions;
+
+    for (final marker in markers) {
+      if (marker.offset <= offset) {
+        markerBefore = marker;
+      }
+      if (marker.offset > offset) {
+        break;
+      }
+    }
+
+    return markerBefore;
+  }
+
+  SpanMarker? _getMarkerAt(dynamic attribution, int offset) {
+    return attributions
+        .where((marker) => marker.attribution == attribution)
+        .firstWhereOrNull((marker) => marker.offset == offset);
+  }
+
+  /// Preconditions:
+  ///  - there must not already exist a marker with the same
+  ///    attribution at the same offset.
+  void _insertMarker(SpanMarker newMarker) {
+    SpanMarker? markerAfter =
+        attributions.firstWhereOrNull((existingMarker) => existingMarker.offset >= newMarker.offset);
+
+    if (markerAfter != null) {
+      final markerAfterIndex = attributions.indexOf(markerAfter);
+      attributions.insert(markerAfterIndex, newMarker);
+    } else {
+      // Insert the new marker at the end.
+      attributions.add(newMarker);
+    }
+  }
+
+  /// Preconditions:
+  ///  - `marker` must exist in the `attributions` list.
+  void _removeMarker(SpanMarker marker) {
+    final index = attributions.indexOf(marker);
+    if (index < 0) {
+      throw Exception('Tried to remove a marker that isn\'t in attributions list: $marker');
+    }
+    attributions.removeAt(index);
+  }
+
+  /// Pushes back all the spans in `other` by the length of this
+  /// `AttributedSpans`, and then appends the `other` spans to this
+  /// `AttributedSpans`.
+  void addToEnd(AttributedSpans other) {
+    print('addToEnd()');
+    print(' - our attributions before pushing them:');
+    print(toString());
+
+    // Push back all the `other` markers to make room for the
+    // spans we're putting in front of them.
+
+    final pushDistance = _length;
+    print(' - pushing `other` markers by: $pushDistance');
+    print(' - `other` attributions before pushing them:');
+    print(other);
+    final pushedSpans = other.copy()..pushAttributionsBack(pushDistance);
+
+    // Combine `this` and `other` attributions into one list.
+    final List<SpanMarker> combinedAttributions = List.from(attributions)..addAll(pushedSpans.attributions);
+    print(' - combined attributions before merge:');
+    print(combinedAttributions);
+
+    // Clean up the boundary between the two lists of attributions
+    // by merging compatible attributions that meet at the boundary.
+    _mergeBackToBackAttributions(combinedAttributions, _length - 1);
+
+    print(' - combined attributions after merge:');
+    for (final marker in combinedAttributions) {
+      print('   - $marker');
+    }
+
+    attributions
+      ..clear()
+      ..addAll(combinedAttributions);
+  }
+
+  void _mergeBackToBackAttributions(List<SpanMarker> attributions, int mergePoint) {
+    print(' - merging attributions at $mergePoint');
+    // Look for any compatible attributions at
+    // `mergePoint` and `mergePoint+1` and combine them.
+    final startEdgeMarkers = attributions.where((marker) => marker.offset == mergePoint).toList();
+    final endEdgeMarkers = attributions.where((marker) => marker.offset == mergePoint + 1).toList();
+    for (final startEdgeMarker in startEdgeMarkers) {
+      print(' - marker on left side: $startEdgeMarker');
+      final matchingEndEdgeMarker = endEdgeMarkers.firstWhereOrNull(
+        (marker) => marker.attribution == startEdgeMarker.attribution && marker.isStart,
+      );
+      print(' - matching marker on right side? $matchingEndEdgeMarker');
+      if (startEdgeMarker.isEnd && matchingEndEdgeMarker != null) {
+        // These two attributions should be combined into one.
+        // To do this, delete these two markers from the original
+        // attribution list.
+        print(' - removing both markers because they offset each other');
+        attributions..remove(startEdgeMarker)..remove(matchingEndEdgeMarker);
+      }
+    }
+  }
+
+  /// Returns of a copy of this `AttributedSpans` between `startOffset`
+  /// and `endOffset`.
+  ///
+  /// If no `endOffset` is provided, a copy is made from `startOffset`
+  /// to the end of this `AttributedSpans`.
+  AttributedSpans copyAttributionRegion(int startOffset, [int? endOffset]) {
+    endOffset = endOffset ?? _length - 1;
+    print('_copyAttributionRegion() - start: $startOffset, end: $endOffset');
+
+    final List<SpanMarker> cutAttributions = [];
+
+    print(' - inspecting existing markers in full AttributedSpans');
+    final Map<dynamic, int> foundStartMarkers = {};
+    final Map<dynamic, int> foundEndMarkers = {};
+
+    // Analyze all markers that appear before the start of
+    // the copy range so that we can insert any appropriate
+    // `start` markers at the beginning of the copy range.
+    attributions //
+        .where((marker) => marker.offset < startOffset) //
+        .forEach((marker) {
+      print(' - marker before the copy region: $marker');
+      // Track any markers that begin before the `startOffset`
+      // and continue beyond `startOffset`.
+      if (marker.isStart) {
+        print(' - remembering this marker to insert in copied region');
+        foundStartMarkers.putIfAbsent(marker.attribution, () => 0);
+        foundStartMarkers[marker.attribution] = foundStartMarkers[marker.attribution]! + 1;
+      } else {
+        print(
+            ' - this marker counters an earlier one we found. We will not re-insert this marker in the copied region');
+        foundStartMarkers.putIfAbsent(marker.attribution, () => 0);
+        foundStartMarkers[marker.attribution] = foundStartMarkers[marker.attribution]! - 1;
+      }
+    });
+
+    // Insert any `start` markers at the start of the copy region
+    // so that we maintain attribution symmetry.
+    foundStartMarkers.forEach((markerAttribution, count) {
+      if (count == 1) {
+        // Found an unmatched `start` marker. Replace it.
+        print(' - inserting "$markerAttribution" marker at start of copy region to maintain symmetry.');
+        cutAttributions.add(SpanMarker(
+          attribution: markerAttribution,
+          offset: 0,
+          markerType: SpanMarkerType.start,
+        ));
+      } else if (count < 0 || count > 1) {
+        throw Exception(
+            'Found an unbalanced number of `start` and `end` markers before offset: $startOffset - $attributions');
+      }
+    });
+
+    // Directly copy every marker that appears within the cut
+    // region.
+    attributions //
+        .where((marker) => startOffset <= marker.offset && marker.offset <= endOffset!) //
+        .forEach((marker) {
+      print(' - copying "${marker.attribution}" at ${marker.offset} from original AttributionSpans to copy region.');
+      cutAttributions.add(marker.copyWith(
+        offset: marker.offset - startOffset,
+      ));
+    });
+
+    // Analyze all markers that appear after the end of
+    // the copy range so that we can insert any appropriate
+    // `end` markers at the end of the copy range.
+    attributions //
+        .reversed //
+        .where((marker) => marker.offset > endOffset!) //
+        .forEach((marker) {
+      print(' - marker after the copy region: $marker');
+      // Track any markers that end after the `endOffset`
+      // and start before `endOffset`.
+      if (marker.isEnd) {
+        print(' - remembering this marker to insert in copied region');
+        foundEndMarkers.putIfAbsent(marker.attribution, () => 0);
+        foundEndMarkers[marker.attribution] = foundEndMarkers[marker.attribution]! + 1;
+      } else {
+        print(
+            ' - this marker counters an earlier one we found. We will not re-insert this marker in the copied region');
+        foundEndMarkers.putIfAbsent(marker.attribution, () => 0);
+        foundEndMarkers[marker.attribution] = foundEndMarkers[marker.attribution]! - 1;
+      }
+    });
+
+    // Insert any `end` markers at the end of the copy region
+    // so that we maintain attribution symmetry.
+    foundEndMarkers.forEach((markerAttribution, count) {
+      if (count == 1) {
+        // Found an unmatched `end` marker. Replace it.
+        print(' - inserting "$markerAttribution" marker at end of copy region to maintain symmetry.');
+        cutAttributions.add(SpanMarker(
+          attribution: markerAttribution,
+          offset: endOffset! - startOffset,
+          markerType: SpanMarkerType.end,
+        ));
+      } else if (count < 0 || count > 1) {
+        throw Exception(
+            'Found an unbalanced number of `start` and `end` markers after offset: $endOffset - $attributions');
+      }
+    });
+
+    print(' - copied attributions:');
+    for (final attribution in cutAttributions) {
+      print('   - $attribution');
+    }
+
+    return AttributedSpans(attributions: cutAttributions);
+  }
+
+  /// Changes all spans in this `AttributedSpans` by pushing
+  /// them back by `offset` amount.
+  void pushAttributionsBack(int offset) {
+    final pushedAttributions = attributions.map((marker) => marker.copyWith(offset: marker.offset + offset)).toList();
+    attributions
+      ..clear()
+      ..addAll(pushedAttributions);
+  }
+
+  /// Changes spans in this `AttributedSpans` by cutting out the
+  /// region from `startOffset` to `startOffset + count`, exclusive.
+  void contractAttributions({
+    required int startOffset,
+    required int count,
+  }) {
+    final contractedAttributions = <SpanMarker>[];
+
+    // Add all the markers that are unchanged.
+    contractedAttributions.addAll(attributions.where((marker) => marker.offset < startOffset));
+
+    print(' - removing $count characters starting at $startOffset');
+    final needToEndAttributions = <dynamic>{};
+    final needToStartAttributions = <dynamic>{};
+    attributions
+        .where((marker) => (startOffset <= marker.offset) && (marker.offset < startOffset + count))
+        .forEach((marker) {
+      // Get rid of this marker and keep track of
+      // any open-ended attributions that need to
+      // be closed.
+      print(' - removing ${marker.markerType} at ${marker.offset}');
+      if (marker.isStart) {
+        if (needToEndAttributions.contains(marker.attribution)) {
+          // We've already removed an `end` marker so now
+          // we're even.
+          needToEndAttributions.remove(marker.attribution);
+        } else {
+          // We've removed a `start` marker that needs to
+          // be replaced down the line.
+          needToStartAttributions.add(marker.attribution);
+        }
+      } else {
+        if (needToStartAttributions.contains(marker.attribution)) {
+          // We've already removed a `start` marker so now
+          // we're even.
+          needToStartAttributions.remove(marker.attribution);
+        } else {
+          // We've removed an `end` marker that needs to
+          // be replaced down the line.
+          needToEndAttributions.add(marker.attribution);
+        }
+      }
+    });
+
+    // Re-insert any markers that are needed to retain
+    // symmetry after the deletions above.
+    needToStartAttributions.forEach((attribution) {
+      final offset = startOffset > 0 ? startOffset - 1 : 0;
+      print(' - adding back a start marker at $offset');
+      contractedAttributions.add(SpanMarker(
+        attribution: attribution,
+        offset: offset,
+        markerType: SpanMarkerType.start,
+      ));
+    });
+    needToEndAttributions.forEach((attribution) {
+      final offset = startOffset > 0 ? startOffset - 1 : 0;
+      print(' - adding back an end marker at $offset');
+      contractedAttributions.add(SpanMarker(
+        attribution: attribution,
+        offset: offset,
+        markerType: SpanMarkerType.end,
+      ));
+    });
+
+    // Add all remaining markers but with an `offset`
+    // that is less by `count`.
+    contractedAttributions.addAll(
+      attributions
+          .where((marker) => marker.offset >= startOffset + count)
+          .map((marker) => marker.copyWith(offset: marker.offset - count)),
+    );
+
+    attributions
+      ..clear()
+      ..addAll(contractedAttributions);
+  }
+
+  /// Returns a copy of this `AttributedSpans`.
+  AttributedSpans copy() {
+    return AttributedSpans(
+      length: _length,
+      attributions: List.from(attributions),
+    );
+  }
+
+  /// Combines all spans of different types into a single
+  /// list of spans that contain multiple types per segment.
+  ///
+  /// The returns spans are ordered.
+  List<MultiAttributionSpan> collapseSpans() {
+    print('collapseSpans() - content length: $_length');
+    print(' - attributions used to compute spans:');
+    for (final marker in attributions) {
+      print('   - $marker');
+    }
+
+    if (_length == 0) {
+      // There is no content and therefore no attributions.
+      print(' - content is empty. Returning empty span list.');
+      return [];
+    }
+
+    // Cut up attributions in a series of corresponding "start"
+    // and "end" points for every different combination of
+    // attributions.
+    final startPoints = <int>[0]; // we always start at zero
+    final endPoints = <int>[];
+
+    print(' - accumulating start and end points:');
+    for (final marker in attributions) {
+      print(' - marker at ${marker.offset}');
+      print(' - start points before change: $startPoints');
+      print(' - end points before change: $endPoints');
+
+      if (marker.isStart) {
+        // Add a `start` point.
+        if (!startPoints.contains(marker.offset)) {
+          print(' - adding start point at ${marker.offset}');
+          startPoints.add(marker.offset);
+        }
+
+        // If there are no attributions before this `start` point
+        // then there won't be an `end` just before this
+        // `start` point. Insert one.
+        if (marker.offset > 0 && !endPoints.contains(marker.offset - 1)) {
+          print(' - going back one and adding end point at: ${marker.offset - 1}');
+          endPoints.add(marker.offset - 1);
+        }
+      }
+      if (marker.isEnd) {
+        // Add an `end` point.
+        if (!endPoints.contains(marker.offset)) {
+          print(' - adding an end point at: ${marker.offset}');
+          endPoints.add(marker.offset);
+        }
+
+        // Automatically start another range if we aren't at
+        // the end of the content. We do this because we're not
+        // guaranteed to have another `start` marker after this
+        // `end` marker.
+        if (marker.offset < _length - 1 && !startPoints.contains(marker.offset + 1)) {
+          print(' - jumping forward one to add a start point at: ${marker.offset + 1}');
+          startPoints.add(marker.offset + 1);
+        }
+      }
+
+      print(' - start points after change: $startPoints');
+      print(' - end points after change: $endPoints');
+    }
+    if (!endPoints.contains(_length - 1)) {
+      // This condition occurs when there are no attributions.
+      print(' - adding a final endpoint at end of text');
+      endPoints.add(_length - 1);
+    }
+
+    if (startPoints.length != endPoints.length) {
+      print(' - start points: $startPoints');
+      print(' - end points: $endPoints');
+      throw Exception(
+          ' - mismatch between number of start points and end points. Content length: $_length, Start: ${startPoints.length} -> ${startPoints}, End: ${endPoints.length} -> ${endPoints}, from attributions: ${attributions}');
+    }
+
+    // Sort the start and end points so that they can be
+    // processed from beginning to end.
+    startPoints.sort();
+    endPoints.sort();
+
+    // Create the collapsed spans.
+    List<MultiAttributionSpan> collapsedSpans = [];
+    for (int i = 0; i < startPoints.length; ++i) {
+      print(' - building span from ${startPoints[i]} -> ${endPoints[i]}');
+      collapsedSpans.add(MultiAttributionSpan(
+        start: startPoints[i],
+        end: endPoints[i],
+        attributions: getAllAttributionsAt(startPoints[i]),
+      ));
+    }
+    return collapsedSpans;
+  }
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('[AttributedSpans] (${(attributions.length / 2).round()} spans):');
+    for (final marker in attributions) {
+      buffer.write('\n - $marker');
+    }
+    return buffer.toString();
+  }
+}
+
+/// Marks the start or end of an attribution span.
+///
+/// The given `AttributionType` must implement equality for
+/// span management to work correctly.
+class SpanMarker<AttributionType> implements Comparable<SpanMarker<AttributionType>> {
+  const SpanMarker({
+    required this.attribution,
+    required this.offset,
+    required this.markerType,
+  });
+
+  final AttributionType attribution;
+  final int offset;
+  final SpanMarkerType markerType;
+
+  bool get isStart => markerType == SpanMarkerType.start;
+
+  bool get isEnd => markerType == SpanMarkerType.end;
+
+  SpanMarker copyWith({
+    AttributionType? attribution,
+    int? offset,
+    SpanMarkerType? markerType,
+  }) =>
+      SpanMarker(
+        attribution: attribution ?? this.attribution,
+        offset: offset ?? this.offset,
+        markerType: markerType ?? this.markerType,
+      );
+
+  @override
+  String toString() => '[SpanMarker] - attribution: $attribution, offset: $offset, type: $markerType';
+
+  @override
+  int compareTo(SpanMarker other) {
+    return offset - other.offset;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SpanMarker &&
+          attribution == other.attribution &&
+          offset == other.offset &&
+          markerType == other.markerType;
+
+  @override
+  int get hashCode => attribution.hashCode ^ offset.hashCode ^ markerType.hashCode;
+}
+
+enum SpanMarkerType {
+  start,
+  end,
+}
+
+class MultiAttributionSpan {
+  const MultiAttributionSpan({
+    required this.start,
+    required this.end,
+    required this.attributions,
+  });
+
+  final int start;
+  final int end;
+  final Set<dynamic> attributions;
+}

--- a/lib/src/infrastructure/attributed_text.dart
+++ b/lib/src/infrastructure/attributed_text.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/painting.dart';
 
 import 'attributed_spans.dart';
+import '_logging.dart';
+
+final _log = Logger(scope: 'AttributedText');
 
 /// Text with attributions applied to desired spans of text.
 ///
@@ -83,7 +86,7 @@ class AttributedText {
   /// Copies all text and attributions from `startOffset` to
   /// `endOffset`, inclusive, and returns them as a new `AttributedText`.
   AttributedText copyText(int startOffset, [int? endOffset]) {
-    print('copyText() - start: $startOffset, end: $endOffset');
+    _log.log('copyText', 'start: $startOffset, end: $endOffset');
 
     // Note: -1 because copyText() uses an exclusive `start` and `end` but
     // _copyAttributionRegion() uses an inclusive `start` and `end`.
@@ -96,7 +99,7 @@ class AttributedText {
     } else {
       endCopyOffset = text.length - 1;
     }
-    print(' - copy offsets, start: $startCopyOffset, end: $endCopyOffset');
+    _log.log('copyText', 'offsets, start: $startCopyOffset, end: $endCopyOffset');
 
     return AttributedText(
       text: text.substring(startOffset, endOffset),
@@ -107,11 +110,10 @@ class AttributedText {
   /// Returns a copy of this `AttributedText` with the `other` text
   /// and attributions appended to the end.
   AttributedText copyAndAppend(AttributedText other) {
-    print('copyAndAppend()');
-    print(' - our attributions before pushing them:');
-    print(spans);
+    _log.log('copyAndAppend', 'our attributions before pushing them:');
+    _log.log('copyAndAppend', spans.toString());
     if (other.text.isEmpty) {
-      print(' - `other` has no text. Returning a direct copy of ourselves.');
+      _log.log('copyAndAppend', '`other` has no text. Returning a direct copy of ourselves.');
       return AttributedText(
         text: text,
         spans: spans.copy(),
@@ -136,17 +138,17 @@ class AttributedText {
     required int startOffset,
     Set<dynamic> applyAttributions = const {},
   }) {
-    print('insertString() - text: "$textToInsert", start: $startOffset, attributions: $applyAttributions');
+    _log.log('insertString', 'text: "$textToInsert", start: $startOffset, attributions: $applyAttributions');
 
-    print(' - copying text to the left');
+    _log.log('insertString', 'copying text to the left');
     final startText = this.copyText(0, startOffset);
-    print(' - startText: $startText');
+    _log.log('insertString', 'startText: $startText');
 
-    print(' - copying text to the right');
+    _log.log('insertString', 'copying text to the right');
     final endText = this.copyText(startOffset);
-    print(' - endText: $endText');
+    _log.log('insertString', 'endText: $endText');
 
-    print(' - creating new attributed text for insertion');
+    _log.log('insertString', 'creating new attributed text for insertion');
     final insertedText = AttributedText(
       text: textToInsert,
     );
@@ -154,9 +156,9 @@ class AttributedText {
     for (dynamic attribution in applyAttributions) {
       insertedText.addAttribution(attribution, insertTextRange);
     }
-    print(' - insertedText: $insertedText');
+    _log.log('insertString', 'insertedText: $insertedText');
 
-    print(' - combining left text, insertion text, and right text');
+    _log.log('insertString', 'combining left text, insertion text, and right text');
     return startText.copyAndAppend(insertedText).copyAndAppend(endText);
   }
 
@@ -167,9 +169,9 @@ class AttributedText {
     required int startOffset,
     required int endOffset,
   }) {
-    print('Removing text region from $startOffset to $endOffset');
-    print(' - initial attributions:');
-    print(spans);
+    _log.log('removeRegion', 'Removing text region from $startOffset to $endOffset');
+    _log.log('removeRegion', 'initial attributions:');
+    _log.log('removeRegion', spans.toString());
     final reducedText = (startOffset > 0 ? text.substring(0, startOffset) : '') +
         (endOffset < text.length ? text.substring(endOffset) : '');
 
@@ -178,9 +180,9 @@ class AttributedText {
         startOffset: startOffset,
         count: endOffset - startOffset,
       );
-    print(' - reduced text length: ${reducedText.length}');
-    print(' - remaining attributions:');
-    print(contractedAttributions);
+    _log.log('removeRegion', 'reduced text length: ${reducedText.length}');
+    _log.log('removeRegion', 'remaining attributions:');
+    _log.log('removeRegion', contractedAttributions.toString());
 
     return AttributedText(
       text: reducedText,
@@ -194,13 +196,13 @@ class AttributedText {
   /// The given `styleBuilder` interprets the meaning of every
   /// attribution and constructs `TextStyle`s accordingly.
   TextSpan computeTextSpan(AttributionStyleBuilder styleBuilder) {
-    print('computeTextSpan() - text length: ${text.length}');
-    print(' - attributions used to compute spans:');
-    print(spans);
+    _log.log('computeTextSpan', 'text length: ${text.length}');
+    _log.log('computeTextSpan', 'attributions used to compute spans:');
+    _log.log('computeTextSpan', spans.toString());
 
     if (text.isEmpty) {
       // There is no text and therefore no attributions.
-      print(' - text is empty. Returning empty TextSpan.');
+      _log.log('computeTextSpan', 'text is empty. Returning empty TextSpan.');
       return TextSpan(text: '', style: styleBuilder({}));
     }
 

--- a/lib/src/infrastructure/attributed_text.dart
+++ b/lib/src/infrastructure/attributed_text.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/painting.dart';
+
+import 'attributed_spans.dart';
+
+/// Text with attributions applied to desired spans of text.
+///
+/// An attribution can be any object as long as each attribution
+/// object implements equality such that any two instances of an
+/// equivalent attribution are considered equal. A `String` is
+/// typically a good choice to use as an attribution type.
+class AttributedText {
+  AttributedText({
+    this.text = '',
+    List<SpanMarker>? attributions,
+  }) : _spans = AttributedSpans(length: text.length, attributions: attributions ?? []);
+
+  final String text;
+  final AttributedSpans _spans;
+
+  /// Returns true if the text has the given attribution at
+  /// `offset`, or false otherwise.
+  bool hasAttributionAt(
+    int offset, {
+    dynamic attribution,
+  }) {
+    return _spans.hasAttributionAt(offset, attribution: attribution);
+  }
+
+  /// Returns true if the text contains at least one character of
+  /// attribution for each of the given `attributions` within the
+  /// given `range`, returns false otherwise.
+  bool hasAttributionsWithin({
+    required Set<dynamic> attributions,
+    required TextRange range,
+  }) {
+    return _spans.hasAttributionsWithin(
+      attributions: attributions,
+      start: range.start,
+      end: range.end,
+    );
+  }
+
+  /// Returns all attributions that cover the given `offset` within
+  /// the text.
+  Set<dynamic> getAllAttributionsAt(int offset) {
+    return _spans.getAllAttributionsAt(offset);
+  }
+
+  /// Adds the given attribution to all characters within the given
+  /// `range`, inclusive.
+  void addAttribution(dynamic attribution, TextRange range) {
+    _spans.addAttribution(newAttribution: attribution, start: range.start, end: range.end);
+  }
+
+  /// Removes the given attribution from all characters within the
+  /// given `range`, inclusive.
+  void removeAttribution(dynamic attribution, TextRange range) {
+    _spans.addAttribution(newAttribution: attribution, start: range.start, end: range.end);
+  }
+
+  /// If ALL of the text in `range` contains the given `attribution`,
+  /// that attribution is removed from the text in `range`.
+  /// Otherwise, all of the text in `range` is given the `attribution`.
+  void toggleAttribution(dynamic attribution, TextRange range) {
+    _spans.toggleAttribution(attribution: attribution, start: range.start, end: range.end);
+  }
+
+  TextSpan computeTextSpan(AttributionStyleBuilder styleBuilder) {
+    print('computeTextSpan() - text length: ${text.length}');
+    print(' - attributions used to compute spans:');
+    print(_spans);
+
+    if (text.isEmpty) {
+      // There is no text and therefore no attributions.
+      print(' - text is empty. Returning empty TextSpan.');
+      return TextSpan(text: '', style: styleBuilder({}));
+    }
+
+    final collapsedSpans = _spans.collapseSpans();
+    final textSpans = collapsedSpans
+        .map((attributedSpan) => TextSpan(
+              text: text.substring(attributedSpan.start, attributedSpan.end + 1),
+              style: styleBuilder(attributedSpan.attributions),
+            ))
+        .toList();
+
+    return textSpans.length == 1
+        ? textSpans.first
+        : TextSpan(
+            children: textSpans,
+            style: styleBuilder({}),
+          );
+  }
+
+  /// Copies all text and attributions from `startOffset` to
+  /// `endOffset`, inclusive.
+  AttributedText copyText(int startOffset, [int? endOffset]) {
+    print('copyText() - start: $startOffset, end: $endOffset');
+
+    // Note: -1 because copyText() uses an exclusive `start` and `end` but
+    // _copyAttributionRegion() uses an inclusive `start` and `end`.
+    final startCopyOffset = startOffset < text.length ? startOffset : text.length - 1;
+    int endCopyOffset;
+    if (endOffset == startOffset) {
+      endCopyOffset = startCopyOffset;
+    } else if (endOffset != null) {
+      endCopyOffset = endOffset - 1;
+    } else {
+      endCopyOffset = text.length - 1;
+    }
+    print(' - copy offsets, start: $startCopyOffset, end: $endCopyOffset');
+
+    return AttributedText(
+      text: text.substring(startOffset, endOffset),
+      attributions: _spans.copyAttributionRegion(startCopyOffset, endCopyOffset).attributions,
+    );
+  }
+
+  /// Copies this `AttributedText` and appends the text and spans
+  /// in the `other` AttributedText` to the end of the copy.
+  AttributedText copyAndAppend(AttributedText other) {
+    print('copyAndAppend()');
+    print(' - our attributions before pushing them:');
+    print(_spans);
+    if (other.text.isEmpty) {
+      print(' - `other` has no text. Returning a direct copy of ourselves.');
+      return AttributedText(
+        text: text,
+        attributions: _spans.copy().attributions,
+      );
+    }
+
+    final newSpans = _spans.copy()..addToEnd(other._spans);
+    return AttributedText(
+      text: text + other.text,
+      attributions: newSpans.attributions,
+    );
+  }
+
+  /// Returns a copy of this `AttributedText` with `textToInsert`
+  /// inserted at `startOffset`.
+  ///
+  /// Any attributions that spanned `startOffset` are applied to
+  /// the inserted text. All spans that start after `startOffset`
+  /// are pushed back by the length of `textToInsert`.
+  AttributedText insertString({
+    required String textToInsert,
+    required int startOffset,
+    Set<dynamic> applyAttributions = const {},
+  }) {
+    print('insertString() - text: "$textToInsert", start: $startOffset, attributions: $applyAttributions');
+
+    print(' - copying text to the left');
+    final startText = this.copyText(0, startOffset);
+    print(' - startText: $startText');
+
+    print(' - copying text to the right');
+    final endText = this.copyText(startOffset);
+    print(' - endText: $endText');
+
+    print(' - creating new attributed text for insertion');
+    final insertedText = AttributedText(
+      text: textToInsert,
+    );
+    final insertTextRange = TextRange(start: 0, end: textToInsert.length - 1);
+    for (dynamic attribution in applyAttributions) {
+      insertedText.addAttribution(attribution, insertTextRange);
+    }
+    print(' - insertedText: $insertedText');
+
+    print(' - combining left text, insertion text, and right text');
+    return startText.copyAndAppend(insertedText).copyAndAppend(endText);
+  }
+
+  /// Cuts a region of text and attributions from `startOffset`,
+  /// inclusive, to `endOffset`, exclusive.
+  AttributedText removeRegion({
+    required int startOffset,
+    required int endOffset,
+  }) {
+    print('Removing text region from $startOffset to $endOffset');
+    print(' - initial attributions:');
+    print(_spans);
+    final reducedText = (startOffset > 0 ? text.substring(0, startOffset) : '') +
+        (endOffset < text.length ? text.substring(endOffset) : '');
+
+    AttributedSpans contractedAttributions = _spans.copy()
+      ..contractAttributions(
+        startOffset: startOffset,
+        count: endOffset - startOffset,
+      );
+    print(' - reduced text length: ${reducedText.length}');
+    print(' - remaining attributions:');
+    print(contractedAttributions);
+
+    return AttributedText(
+      text: reducedText,
+      attributions: contractedAttributions.attributions,
+    );
+  }
+
+  @override
+  String toString() {
+    return '[AttributedText] - "$text"\n' + _spans.toString();
+  }
+}
+
+/// Creates the desired `TextStyle` given the `attributions` associated
+/// with a span of text.
+///
+/// The `attributions` set may be empty.
+typedef AttributionStyleBuilder = TextStyle Function(Set<dynamic> attributions);

--- a/test/src/infrastructure/attributed_spans_test.dart
+++ b/test/src/infrastructure/attributed_spans_test.dart
@@ -314,12 +314,9 @@ class _ExpectedSpans {
   void expectSpans(AttributedSpans spans) {
     for (int characterIndex = 0; characterIndex < _combinedSpans.length; ++characterIndex) {
       for (int attributionIndex = 0; attributionIndex < _combinedSpans[characterIndex].length; ++attributionIndex) {
-        print('Checking character $characterIndex');
         // The attribution name is just a letter, like 'b', 'i', or 's'.
         final attributionName = _combinedSpans[characterIndex][attributionIndex];
-        print(' - looking for attribution: "$attributionName"');
         if (attributionName == '_') {
-          print(' - skipping empty template character');
           continue;
         }
 

--- a/test/src/infrastructure/attributed_spans_test.dart
+++ b/test/src/infrastructure/attributed_spans_test.dart
@@ -1,0 +1,274 @@
+import 'package:flutter_richtext/src/infrastructure/attributed_spans.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Spans', () {
+    group('single attribution', () {
+      test('applies attribution to full span', () {
+        final spans = AttributedSpans(length: 17);
+
+        spans.addAttribution(newAttribution: 'bold', start: 0, end: 16);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), true);
+      });
+
+      test('applies attribution to beginning of span', () {
+        final spans = AttributedSpans(length: 17);
+
+        spans.addAttribution(newAttribution: 'bold', start: 0, end: 7);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 7), true);
+      });
+
+      test('applies attribution to inner span', () {
+        final spans = AttributedSpans(length: 17);
+
+        spans.addAttribution(newAttribution: 'bold', start: 2, end: 7);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 7), true);
+      });
+
+      test('applies attribution to end of span', () {
+        final spans = AttributedSpans(length: 17);
+
+        spans.addAttribution(newAttribution: 'bold', start: 7, end: 16);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 7, end: 16), true);
+      });
+
+      test('applies exotic span', () {
+        final spans = AttributedSpans(length: 17);
+
+        final linkAttribution = {
+          'url': 'https://youtube.com/c/superdeclarative',
+        };
+
+        spans.addAttribution(newAttribution: linkAttribution, start: 2, end: 7);
+
+        expect(spans.hasAttributionsWithin(attributions: {linkAttribution}, start: 2, end: 7), true);
+      });
+
+      test('removes attribution from full span', () {
+        final spans = AttributedSpans(
+          length: 17,
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
+          ],
+        );
+
+        spans.removeAttribution(attributionToRemove: 'bold', start: 0, end: 16);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), false);
+      });
+
+      test('removes attribution from inner text span', () {
+        final spans = AttributedSpans(
+          length: 17,
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
+          ],
+        );
+
+        spans.removeAttribution(attributionToRemove: 'bold', start: 2, end: 7);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 7), false);
+      });
+
+      test('removes attribution from partial beginning span', () {
+        final spans = AttributedSpans(
+          length: 17,
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
+          ],
+        );
+
+        spans.removeAttribution(attributionToRemove: 'bold', start: 2, end: 4);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 5, end: 7), true);
+      });
+
+      test('removes attribution from partial inner span', () {
+        final spans = AttributedSpans(
+          length: 17,
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
+          ],
+        );
+
+        spans.removeAttribution(attributionToRemove: 'bold', start: 4, end: 5);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 3), true);
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 6, end: 7), true);
+      });
+
+      test('removes attribution from partial ending span', () {
+        final spans = AttributedSpans(
+          length: 17,
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
+          ],
+        );
+
+        spans.removeAttribution(attributionToRemove: 'bold', start: 5, end: 7);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 4), true);
+      });
+
+      test('applies attribution when mixed span is toggled', () {
+        final spans = AttributedSpans(
+          length: 17,
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 8, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
+          ],
+        );
+
+        spans.toggleAttribution(attribution: 'bold', start: 0, end: 16);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), true);
+      });
+
+      test('removes attribution when contiguous span is toggled', () {
+        final spans = AttributedSpans(
+          length: 17,
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
+          ],
+        );
+
+        spans.toggleAttribution(attribution: 'bold', start: 0, end: 16);
+
+        expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), false);
+      });
+    });
+
+    group('multiple attributions', () {
+      test('full length overlap', () {
+        final spans = AttributedSpans(
+          length: 10,
+        );
+        spans.addAttribution(newAttribution: 'b', start: 0, end: 9);
+        spans.addAttribution(newAttribution: 'i', start: 0, end: 9);
+        final expectedAttributions1 = _ExpectedSpans([
+          'bbbbbbbbbb',
+          'iiiiiiiiii',
+        ]);
+        expectedAttributions1.expectSpans(spans);
+      });
+
+      test('half and half', () {
+        final spans = AttributedSpans(
+          length: 10,
+        );
+        spans.addAttribution(newAttribution: 'b', start: 5, end: 9);
+        spans.addAttribution(newAttribution: 'i', start: 0, end: 4);
+        final expectedAttributions2 = _ExpectedSpans([
+          '_____bbbbb',
+          'iiiii_____',
+        ]);
+        expectedAttributions2.expectSpans(spans);
+      });
+
+      test('two partial overlap', () {
+        final spans = AttributedSpans(
+          length: 10,
+        );
+        spans.addAttribution(newAttribution: 'b', start: 4, end: 8);
+        spans.addAttribution(newAttribution: 'i', start: 1, end: 5);
+        final expectedAttributions3 = _ExpectedSpans([
+          '____bbbbb_',
+          '_iiiii____',
+        ]);
+        expectedAttributions3.expectSpans(spans);
+      });
+
+      test('three partial overlap', () {
+        final spans = AttributedSpans(
+          length: 10,
+        );
+        spans.addAttribution(newAttribution: 'b', start: 4, end: 8);
+        spans.addAttribution(newAttribution: 'i', start: 1, end: 5);
+        spans.addAttribution(newAttribution: 's', start: 5, end: 9);
+        final expectedAttributions4 = _ExpectedSpans([
+          '____bbbbb_',
+          '_iiiii____',
+          '_____sssss',
+        ]);
+        expectedAttributions4.expectSpans(spans);
+      });
+
+      test('many small segments', () {
+        final spans = AttributedSpans(
+          length: 10,
+        );
+        spans.addAttribution(newAttribution: 'b', start: 0, end: 1);
+        spans.addAttribution(newAttribution: 'i', start: 2, end: 3);
+        spans.addAttribution(newAttribution: 's', start: 4, end: 5);
+        spans.addAttribution(newAttribution: 'b', start: 6, end: 7);
+        spans.addAttribution(newAttribution: 'i', start: 8, end: 9);
+        final expectedAttributions5 = _ExpectedSpans([
+          'bb____bb__',
+          '__ii____ii',
+          '____ss____',
+        ]);
+        expectedAttributions5.expectSpans(spans);
+      });
+    });
+
+    group('collapse spans', () {
+      // TODO: tests to collapse spans
+    });
+  });
+}
+
+class _ExpectedSpans {
+  _ExpectedSpans(
+    List<String> spanTemplates,
+  ) : _combinedSpans = [] {
+    final templateLength = spanTemplates.first.length;
+    for (final template in spanTemplates) {
+      assert(template.length == templateLength);
+    }
+
+    // Collapse spanTemplates down into a single
+    // list of character collections representing the
+    // set of attributions at a given index.
+    _combinedSpans = List.filled(templateLength, '');
+    for (int i = 0; i < templateLength; ++i) {
+      for (final template in spanTemplates) {
+        if (_combinedSpans[i].isEmpty) {
+          _combinedSpans[i] = template[i];
+        } else if (_combinedSpans[i] == '_' && template[i] != '_') {
+          _combinedSpans[i] = template[i];
+        } else if (_combinedSpans[i] != '_' && template[i] != '_') {
+          _combinedSpans[i] += template[i];
+        }
+      }
+    }
+  }
+
+  List<String> _combinedSpans;
+
+  void expectSpans(AttributedSpans spans) {
+    for (int characterIndex = 0; characterIndex < _combinedSpans.length; ++characterIndex) {
+      for (int attributionIndex = 0; attributionIndex < _combinedSpans[characterIndex].length; ++attributionIndex) {
+        print('Checking character $characterIndex');
+        // The attribution name is just a letter, like 'b', 'i', or 's'.
+        final attributionName = _combinedSpans[characterIndex][attributionIndex];
+        print(' - looking for attribution: "$attributionName"');
+        if (attributionName == '_') {
+          print(' - skipping empty template character');
+          continue;
+        }
+
+        expect(spans.hasAttributionAt(characterIndex, attribution: attributionName), true);
+      }
+    }
+  }
+}

--- a/test/src/infrastructure/attributed_spans_test.dart
+++ b/test/src/infrastructure/attributed_spans_test.dart
@@ -5,101 +5,78 @@ void main() {
   group('Spans', () {
     group('single attribution', () {
       test('applies attribution to full span', () {
-        final spans = AttributedSpans(length: 17);
-
-        spans.addAttribution(newAttribution: 'bold', start: 0, end: 16);
+        final spans = AttributedSpans()..addAttribution(newAttribution: 'bold', start: 0, end: 16);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), true);
       });
 
       test('applies attribution to beginning of span', () {
-        final spans = AttributedSpans(length: 17);
-
-        spans.addAttribution(newAttribution: 'bold', start: 0, end: 7);
+        final spans = AttributedSpans()..addAttribution(newAttribution: 'bold', start: 0, end: 7);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 7), true);
       });
 
       test('applies attribution to inner span', () {
-        final spans = AttributedSpans(length: 17);
-
-        spans.addAttribution(newAttribution: 'bold', start: 2, end: 7);
+        final spans = AttributedSpans()..addAttribution(newAttribution: 'bold', start: 2, end: 7);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 7), true);
       });
 
       test('applies attribution to end of span', () {
-        final spans = AttributedSpans(length: 17);
-
-        spans.addAttribution(newAttribution: 'bold', start: 7, end: 16);
+        final spans = AttributedSpans()..addAttribution(newAttribution: 'bold', start: 7, end: 16);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 7, end: 16), true);
       });
 
       test('applies exotic span', () {
-        final spans = AttributedSpans(length: 17);
-
         final linkAttribution = {
           'url': 'https://youtube.com/c/superdeclarative',
         };
-
-        spans.addAttribution(newAttribution: linkAttribution, start: 2, end: 7);
+        final spans = AttributedSpans()..addAttribution(newAttribution: linkAttribution, start: 2, end: 7);
 
         expect(spans.hasAttributionsWithin(attributions: {linkAttribution}, start: 2, end: 7), true);
       });
 
       test('removes attribution from full span', () {
         final spans = AttributedSpans(
-          length: 17,
           attributions: [
             SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
             SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
           ],
-        );
-
-        spans.removeAttribution(attributionToRemove: 'bold', start: 0, end: 16);
+        )..removeAttribution(attributionToRemove: 'bold', start: 0, end: 16);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), false);
       });
 
       test('removes attribution from inner text span', () {
         final spans = AttributedSpans(
-          length: 17,
           attributions: [
             SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
             SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
           ],
-        );
-
-        spans.removeAttribution(attributionToRemove: 'bold', start: 2, end: 7);
+        )..removeAttribution(attributionToRemove: 'bold', start: 2, end: 7);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 7), false);
       });
 
       test('removes attribution from partial beginning span', () {
         final spans = AttributedSpans(
-          length: 17,
           attributions: [
             SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
             SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
           ],
-        );
-
-        spans.removeAttribution(attributionToRemove: 'bold', start: 2, end: 4);
+        )..removeAttribution(attributionToRemove: 'bold', start: 2, end: 4);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 5, end: 7), true);
       });
 
       test('removes attribution from partial inner span', () {
         final spans = AttributedSpans(
-          length: 17,
           attributions: [
             SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
             SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
           ],
-        );
-
-        spans.removeAttribution(attributionToRemove: 'bold', start: 4, end: 5);
+        )..removeAttribution(attributionToRemove: 'bold', start: 4, end: 5);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 3), true);
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 6, end: 7), true);
@@ -107,42 +84,33 @@ void main() {
 
       test('removes attribution from partial ending span', () {
         final spans = AttributedSpans(
-          length: 17,
           attributions: [
             SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
             SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end)
           ],
-        );
-
-        spans.removeAttribution(attributionToRemove: 'bold', start: 5, end: 7);
+        )..removeAttribution(attributionToRemove: 'bold', start: 5, end: 7);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 2, end: 4), true);
       });
 
       test('applies attribution when mixed span is toggled', () {
         final spans = AttributedSpans(
-          length: 17,
           attributions: [
             SpanMarker(attribution: 'bold', offset: 8, markerType: SpanMarkerType.start),
             SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
           ],
-        );
-
-        spans.toggleAttribution(attribution: 'bold', start: 0, end: 16);
+        )..toggleAttribution(attribution: 'bold', start: 0, end: 16);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), true);
       });
 
       test('removes attribution when contiguous span is toggled', () {
         final spans = AttributedSpans(
-          length: 17,
           attributions: [
             SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
             SpanMarker(attribution: 'bold', offset: 16, markerType: SpanMarkerType.end)
           ],
-        );
-
-        spans.toggleAttribution(attribution: 'bold', start: 0, end: 16);
+        )..toggleAttribution(attribution: 'bold', start: 0, end: 16);
 
         expect(spans.hasAttributionsWithin(attributions: {'bold'}, start: 0, end: 16), false);
       });
@@ -150,79 +118,167 @@ void main() {
 
     group('multiple attributions', () {
       test('full length overlap', () {
-        final spans = AttributedSpans(
-          length: 10,
-        );
-        spans.addAttribution(newAttribution: 'b', start: 0, end: 9);
-        spans.addAttribution(newAttribution: 'i', start: 0, end: 9);
-        final expectedAttributions1 = _ExpectedSpans([
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: 'b', start: 0, end: 9)
+          ..addAttribution(newAttribution: 'i', start: 0, end: 9);
+
+        _ExpectedSpans([
           'bbbbbbbbbb',
           'iiiiiiiiii',
-        ]);
-        expectedAttributions1.expectSpans(spans);
+        ]).expectSpans(spans);
       });
 
       test('half and half', () {
-        final spans = AttributedSpans(
-          length: 10,
-        );
-        spans.addAttribution(newAttribution: 'b', start: 5, end: 9);
-        spans.addAttribution(newAttribution: 'i', start: 0, end: 4);
-        final expectedAttributions2 = _ExpectedSpans([
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: 'b', start: 5, end: 9)
+          ..addAttribution(newAttribution: 'i', start: 0, end: 4);
+
+        _ExpectedSpans([
           '_____bbbbb',
           'iiiii_____',
-        ]);
-        expectedAttributions2.expectSpans(spans);
+        ]).expectSpans(spans);
       });
 
       test('two partial overlap', () {
-        final spans = AttributedSpans(
-          length: 10,
-        );
-        spans.addAttribution(newAttribution: 'b', start: 4, end: 8);
-        spans.addAttribution(newAttribution: 'i', start: 1, end: 5);
-        final expectedAttributions3 = _ExpectedSpans([
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: 'b', start: 4, end: 8)
+          ..addAttribution(newAttribution: 'i', start: 1, end: 5);
+
+        _ExpectedSpans([
           '____bbbbb_',
           '_iiiii____',
-        ]);
-        expectedAttributions3.expectSpans(spans);
+        ]).expectSpans(spans);
       });
 
       test('three partial overlap', () {
-        final spans = AttributedSpans(
-          length: 10,
-        );
-        spans.addAttribution(newAttribution: 'b', start: 4, end: 8);
-        spans.addAttribution(newAttribution: 'i', start: 1, end: 5);
-        spans.addAttribution(newAttribution: 's', start: 5, end: 9);
-        final expectedAttributions4 = _ExpectedSpans([
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: 'b', start: 4, end: 8)
+          ..addAttribution(newAttribution: 'i', start: 1, end: 5)
+          ..addAttribution(newAttribution: 's', start: 5, end: 9);
+
+        _ExpectedSpans([
           '____bbbbb_',
           '_iiiii____',
           '_____sssss',
-        ]);
-        expectedAttributions4.expectSpans(spans);
+        ]).expectSpans(spans);
       });
 
       test('many small segments', () {
-        final spans = AttributedSpans(
-          length: 10,
-        );
-        spans.addAttribution(newAttribution: 'b', start: 0, end: 1);
-        spans.addAttribution(newAttribution: 'i', start: 2, end: 3);
-        spans.addAttribution(newAttribution: 's', start: 4, end: 5);
-        spans.addAttribution(newAttribution: 'b', start: 6, end: 7);
-        spans.addAttribution(newAttribution: 'i', start: 8, end: 9);
-        final expectedAttributions5 = _ExpectedSpans([
+        final spans = AttributedSpans()
+          ..addAttribution(newAttribution: 'b', start: 0, end: 1)
+          ..addAttribution(newAttribution: 'i', start: 2, end: 3)
+          ..addAttribution(newAttribution: 's', start: 4, end: 5)
+          ..addAttribution(newAttribution: 'b', start: 6, end: 7)
+          ..addAttribution(newAttribution: 'i', start: 8, end: 9);
+
+        _ExpectedSpans([
           'bb____bb__',
           '__ii____ii',
           '____ss____',
-        ]);
-        expectedAttributions5.expectSpans(spans);
+        ]).expectSpans(spans);
       });
     });
 
     group('collapse spans', () {
-      // TODO: tests to collapse spans
+      test('empty spans', () {
+        // Make sure no exceptions are thrown when collapsing
+        // spans on an empty AttributedSpans.
+        AttributedSpans().collapseSpans(contentLength: 0);
+      });
+
+      test('single continuous attribution', () {
+        final collapsedSpans = AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'b', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'b', offset: 16, markerType: SpanMarkerType.end),
+          ],
+        ).collapseSpans(contentLength: 17);
+
+        expect(collapsedSpans.length, 1);
+        expect(collapsedSpans.first.start, 0);
+        expect(collapsedSpans.first.end, 16);
+        expect(collapsedSpans.first.attributions.length, 1);
+        expect(collapsedSpans.first.attributions.first, 'b');
+      });
+
+      test('single fractured attribution', () {
+        final collapsedSpans = AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'b', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'b', offset: 3, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: 'b', offset: 7, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'b', offset: 10, markerType: SpanMarkerType.end),
+          ],
+        ).collapseSpans(contentLength: 17);
+
+        expect(collapsedSpans.length, 4);
+        expect(collapsedSpans[0].start, 0);
+        expect(collapsedSpans[0].end, 3);
+        expect(collapsedSpans[0].attributions.length, 1);
+        expect(collapsedSpans[0].attributions.first, 'b');
+        expect(collapsedSpans[1].start, 4);
+        expect(collapsedSpans[1].end, 6);
+        expect(collapsedSpans[1].attributions.length, 0);
+        expect(collapsedSpans[2].start, 7);
+        expect(collapsedSpans[2].end, 10);
+        expect(collapsedSpans[2].attributions.length, 1);
+        expect(collapsedSpans[2].attributions.first, 'b');
+        expect(collapsedSpans[3].start, 11);
+        expect(collapsedSpans[3].end, 16);
+        expect(collapsedSpans[3].attributions.length, 0);
+      });
+
+      test('multiple non-overlapping attributions', () {
+        final collapsedSpans = AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'b', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'b', offset: 3, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: 'i', offset: 7, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'i', offset: 10, markerType: SpanMarkerType.end),
+          ],
+        ).collapseSpans(contentLength: 17);
+
+        expect(collapsedSpans.length, 4);
+        expect(collapsedSpans[0].start, 0);
+        expect(collapsedSpans[0].end, 3);
+        expect(collapsedSpans[0].attributions.length, 1);
+        expect(collapsedSpans[0].attributions.first, 'b');
+        expect(collapsedSpans[1].start, 4);
+        expect(collapsedSpans[1].end, 6);
+        expect(collapsedSpans[1].attributions.length, 0);
+        expect(collapsedSpans[2].start, 7);
+        expect(collapsedSpans[2].end, 10);
+        expect(collapsedSpans[2].attributions.length, 1);
+        expect(collapsedSpans[2].attributions.first, 'i');
+        expect(collapsedSpans[3].start, 11);
+        expect(collapsedSpans[3].end, 16);
+        expect(collapsedSpans[3].attributions.length, 0);
+      });
+
+      test('multiple overlapping attributions', () {
+        final collapsedSpans = AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'b', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'b', offset: 8, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: 'i', offset: 6, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'i', offset: 16, markerType: SpanMarkerType.end),
+          ],
+        ).collapseSpans(contentLength: 17);
+
+        expect(collapsedSpans.length, 3);
+        expect(collapsedSpans[0].start, 0);
+        expect(collapsedSpans[0].end, 5);
+        expect(collapsedSpans[0].attributions.length, 1);
+        expect(collapsedSpans[0].attributions.first, 'b');
+        expect(collapsedSpans[1].start, 6);
+        expect(collapsedSpans[1].end, 8);
+        expect(collapsedSpans[1].attributions.length, 2);
+        expect(collapsedSpans[1].attributions, equals({'b', 'i'}));
+        expect(collapsedSpans[2].start, 9);
+        expect(collapsedSpans[2].end, 16);
+        expect(collapsedSpans[2].attributions.length, 1);
+        expect(collapsedSpans[2].attributions.first, 'i');
+      });
     });
   });
 }

--- a/test/src/infrastructure/attributed_text_test.dart
+++ b/test/src/infrastructure/attributed_text_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_richtext/src/infrastructure/attributed_spans.dart';
+import 'package:flutter_richtext/src/infrastructure/attributed_text.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Attributed Text', () {
+    test('no styles', () {
+      final text = AttributedText(
+        text: 'abcdefghij',
+      );
+      final textSpan = text.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, 'abcdefghij');
+      expect(textSpan.children, null);
+    });
+
+    test('full-span style', () {
+      final text = AttributedText(text: 'abcdefghij', attributions: [
+        SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
+        SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.end),
+      ]);
+      final textSpan = text.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, 'abcdefghij');
+      expect(textSpan.style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children, null);
+    });
+
+    test('single character style', () {
+      final text = AttributedText(text: 'abcdefghij', attributions: [
+        SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.start),
+        SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.end),
+      ]);
+      final textSpan = text.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, null);
+      expect(textSpan.children!.length, 3);
+      expect(textSpan.children![0].toPlainText(), 'a');
+      expect(textSpan.children![1].toPlainText(), 'b');
+      expect(textSpan.children![1].style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children![2].toPlainText(), 'cdefghij');
+      expect(textSpan.children![2].style!.fontWeight, null);
+    });
+
+    test('single character style - reverse order', () {
+      final text = AttributedText(text: 'abcdefghij', attributions: [
+        // Notice that the markers are provided in reverse order:
+        // end then start. Order shouldn't matter within a single
+        // position index. This test ensures that.
+        SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.end),
+        SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.start),
+      ]);
+      final textSpan = text.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, null);
+      expect(textSpan.children!.length, 3);
+      expect(textSpan.children![0].toPlainText(), 'a');
+      expect(textSpan.children![1].toPlainText(), 'b');
+      expect(textSpan.children![1].style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children![2].toPlainText(), 'cdefghij');
+      expect(textSpan.children![2].style!.fontWeight, null);
+    });
+
+    test('add single character style', () {
+      final text = AttributedText(text: 'abcdefghij');
+      text.addAttribution('bold', TextRange(start: 1, end: 1));
+      final textSpan = text.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, null);
+      expect(textSpan.children!.length, 3);
+      expect(textSpan.children![0].toPlainText(), 'a');
+      expect(textSpan.children![1].toPlainText(), 'b');
+      expect(textSpan.children![1].style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children![2].toPlainText(), 'cdefghij');
+      expect(textSpan.children![2].style!.fontWeight, null);
+    });
+
+    test('partial style', () {
+      final text = AttributedText(text: 'abcdefghij', attributions: [
+        SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
+        SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end),
+      ]);
+      final textSpan = text.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, null);
+      expect(textSpan.children!.length, 3);
+      expect(textSpan.children![0].toPlainText(), 'ab');
+      expect(textSpan.children![1].toPlainText(), 'cdefgh');
+      expect(textSpan.children![1].style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children![2].toPlainText(), 'ij');
+    });
+
+    test('non-mingled varying styles', () {
+      final text = AttributedText(text: 'abcdefghij', attributions: [
+        SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
+        SpanMarker(attribution: 'bold', offset: 4, markerType: SpanMarkerType.end),
+        SpanMarker(attribution: 'italics', offset: 5, markerType: SpanMarkerType.start),
+        SpanMarker(attribution: 'italics', offset: 9, markerType: SpanMarkerType.end),
+      ]);
+      final textSpan = text.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, null);
+      expect(textSpan.children!.length, 2);
+      expect(textSpan.children![0].toPlainText(), 'abcde');
+      expect(textSpan.children![0].style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children![0].style!.fontStyle, null);
+      expect(textSpan.children![1].toPlainText(), 'fghij');
+      expect(textSpan.children![1].style!.fontWeight, null);
+      expect(textSpan.children![1].style!.fontStyle, FontStyle.italic);
+    });
+
+    test('intermingled varying styles', () {
+      final text = AttributedText(text: 'abcdefghij', attributions: [
+        SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
+        SpanMarker(attribution: 'italics', offset: 4, markerType: SpanMarkerType.start),
+        SpanMarker(attribution: 'bold', offset: 5, markerType: SpanMarkerType.end),
+        SpanMarker(attribution: 'italics', offset: 7, markerType: SpanMarkerType.end),
+      ]);
+      final textSpan = text.computeTextSpan(_styleBuilder);
+
+      expect(textSpan.text, null);
+      expect(textSpan.children!.length, 5);
+      expect(textSpan.children![0].toPlainText(), 'ab');
+      expect(textSpan.children![0].style!.fontWeight, null);
+      expect(textSpan.children![0].style!.fontStyle, null);
+
+      expect(textSpan.children![1].toPlainText(), 'cd');
+      expect(textSpan.children![1].style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children![1].style!.fontStyle, null);
+
+      expect(textSpan.children![2].toPlainText(), 'ef');
+      expect(textSpan.children![2].style!.fontWeight, FontWeight.bold);
+      expect(textSpan.children![2].style!.fontStyle, FontStyle.italic);
+
+      expect(textSpan.children![3].toPlainText(), 'gh');
+      expect(textSpan.children![3].style!.fontWeight, null);
+      expect(textSpan.children![3].style!.fontStyle, FontStyle.italic);
+
+      expect(textSpan.children![4].toPlainText(), 'ij');
+      expect(textSpan.children![4].style!.fontWeight, null);
+      expect(textSpan.children![4].style!.fontStyle, null);
+    });
+  });
+}
+
+/// Creates styles based on the given `attributions`.
+TextStyle _styleBuilder(Set<dynamic> attributions) {
+  TextStyle newStyle = const TextStyle();
+  for (final attribution in attributions) {
+    if (attribution is! String) {
+      continue;
+    }
+
+    switch (attribution) {
+      case 'bold':
+        newStyle = newStyle.copyWith(
+          fontWeight: FontWeight.bold,
+        );
+        break;
+      case 'italics':
+        newStyle = newStyle.copyWith(
+          fontStyle: FontStyle.italic,
+        );
+        break;
+      case 'strikethrough':
+        newStyle = newStyle.copyWith(
+          decoration: TextDecoration.lineThrough,
+        );
+        break;
+    }
+  }
+  return newStyle;
+}

--- a/test/src/infrastructure/attributed_text_test.dart
+++ b/test/src/infrastructure/attributed_text_test.dart
@@ -16,10 +16,15 @@ void main() {
     });
 
     test('full-span style', () {
-      final text = AttributedText(text: 'abcdefghij', attributions: [
-        SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-        SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.end),
-      ]);
+      final text = AttributedText(
+        text: 'abcdefghij',
+        spans: AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 9, markerType: SpanMarkerType.end),
+          ],
+        ),
+      );
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, 'abcdefghij');
@@ -28,10 +33,15 @@ void main() {
     });
 
     test('single character style', () {
-      final text = AttributedText(text: 'abcdefghij', attributions: [
-        SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.start),
-        SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.end),
-      ]);
+      final text = AttributedText(
+        text: 'abcdefghij',
+        spans: AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.end),
+          ],
+        ),
+      );
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);
@@ -44,13 +54,18 @@ void main() {
     });
 
     test('single character style - reverse order', () {
-      final text = AttributedText(text: 'abcdefghij', attributions: [
-        // Notice that the markers are provided in reverse order:
-        // end then start. Order shouldn't matter within a single
-        // position index. This test ensures that.
-        SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.end),
-        SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.start),
-      ]);
+      final text = AttributedText(
+        text: 'abcdefghij',
+        spans: AttributedSpans(
+          attributions: [
+            // Notice that the markers are provided in reverse order:
+            // end then start. Order shouldn't matter within a single
+            // position index. This test ensures that.
+            SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: 'bold', offset: 1, markerType: SpanMarkerType.start),
+          ],
+        ),
+      );
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);
@@ -77,10 +92,15 @@ void main() {
     });
 
     test('partial style', () {
-      final text = AttributedText(text: 'abcdefghij', attributions: [
-        SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
-        SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end),
-      ]);
+      final text = AttributedText(
+        text: 'abcdefghij',
+        spans: AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 7, markerType: SpanMarkerType.end),
+          ],
+        ),
+      );
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);
@@ -92,12 +112,17 @@ void main() {
     });
 
     test('non-mingled varying styles', () {
-      final text = AttributedText(text: 'abcdefghij', attributions: [
-        SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
-        SpanMarker(attribution: 'bold', offset: 4, markerType: SpanMarkerType.end),
-        SpanMarker(attribution: 'italics', offset: 5, markerType: SpanMarkerType.start),
-        SpanMarker(attribution: 'italics', offset: 9, markerType: SpanMarkerType.end),
-      ]);
+      final text = AttributedText(
+        text: 'abcdefghij',
+        spans: AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 0, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 4, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: 'italics', offset: 5, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'italics', offset: 9, markerType: SpanMarkerType.end),
+          ],
+        ),
+      );
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);
@@ -111,12 +136,17 @@ void main() {
     });
 
     test('intermingled varying styles', () {
-      final text = AttributedText(text: 'abcdefghij', attributions: [
-        SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
-        SpanMarker(attribution: 'italics', offset: 4, markerType: SpanMarkerType.start),
-        SpanMarker(attribution: 'bold', offset: 5, markerType: SpanMarkerType.end),
-        SpanMarker(attribution: 'italics', offset: 7, markerType: SpanMarkerType.end),
-      ]);
+      final text = AttributedText(
+        text: 'abcdefghij',
+        spans: AttributedSpans(
+          attributions: [
+            SpanMarker(attribution: 'bold', offset: 2, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'italics', offset: 4, markerType: SpanMarkerType.start),
+            SpanMarker(attribution: 'bold', offset: 5, markerType: SpanMarkerType.end),
+            SpanMarker(attribution: 'italics', offset: 7, markerType: SpanMarkerType.end),
+          ],
+        ),
+      );
       final textSpan = text.computeTextSpan(_styleBuilder);
 
       expect(textSpan.text, null);


### PR DESCRIPTION
`AttributedSpans` and `AttributedText` forms the basis for text styling within the editor. These concepts are conceivably applicable to all sorts of document rendering and editing, so they are placed within the `infrastructure` package.

A very simple logger implementation is added as well so that we can keep useful debug print statements without polluting clients' logs. I've kept this logger private to the package so that we can change it however we want moving forward.

I've included an interactive demo for `AttributedText`. Here is a screenshot:

![Screen Shot 2021-03-11 at 4 55 39 PM](https://user-images.githubusercontent.com/7259036/110876061-a4177d80-828b-11eb-93ca-58f49cd5b942.png)

Eventually, I'm envisioning a kind of interactive story where users can see how an editor is built up from a single `Text` widget. I think this interactive education would help developers adopt the package with a deep understanding of how it works. For now, I'm just focused on individual demos, but they might eventually contribute to a single narrative.