### PR TITLE
Add focusNode and downgrade uuid 

### DIFF
--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -2,8 +2,6 @@
 //  Generated file. Do not edit.
 //
 
-// clang-format off
-
 import FlutterMacOS
 import Foundation
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,14 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.13"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
@@ -50,13 +57,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.5"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -84,7 +98,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -137,7 +151,7 @@ packages:
     dependency: "direct dev"
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.9.2+2"
   linkify:
     dependency: "direct main"
     description:
@@ -228,7 +242,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -240,7 +254,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -268,7 +282,7 @@ packages:
       name: sync_http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -296,7 +310,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:
@@ -310,14 +324,14 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1-nullsafety.1"
+    version: "5.5.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
 
   google_fonts: ^1.1.2
 
-  uuid: ^3.0.1
+  uuid: ^2.2.2
 
   flutter_richtext:
     path: ../

--- a/lib/src/default_editor/editor.dart
+++ b/lib/src/default_editor/editor.dart
@@ -70,6 +70,7 @@ class Editor extends StatefulWidget {
     double maxWidth = 600,
     EdgeInsets padding = EdgeInsets.zero,
     bool showDebugPaint = false,
+    FocusNode? focusNode,
   }) {
     return Editor._(
       key: key,
@@ -83,6 +84,7 @@ class Editor extends StatefulWidget {
       maxWidth: maxWidth,
       padding: padding,
       showDebugPaint: showDebugPaint,
+      focusNode: focusNode,
     );
   }
 
@@ -98,6 +100,7 @@ class Editor extends StatefulWidget {
     double maxWidth = 600,
     EdgeInsets padding = EdgeInsets.zero,
     bool showDebugPaint = false,
+    FocusNode? focusNode,
   }) {
     return Editor._(
       key: key,
@@ -110,6 +113,7 @@ class Editor extends StatefulWidget {
       scrollController: scrollController,
       maxWidth: maxWidth,
       padding: padding,
+      focusNode: focusNode,
       showDebugPaint: showDebugPaint,
     );
   }
@@ -122,11 +126,15 @@ class Editor extends StatefulWidget {
     required this.textStyleBuilder,
     required this.selectionStyle,
     required this.keyboardActions,
+    required this.focusNode,
     this.scrollController,
     this.maxWidth = 600,
     this.padding = EdgeInsets.zero,
     this.showDebugPaint = false,
   }) : super(key: key);
+
+  /// FocusNode to be used to define the editor in the focus tree
+  final FocusNode? focusNode;
 
   /// Contains a `Document` and alters that document as desired.
   final DocumentEditor editor;
@@ -197,16 +205,19 @@ class _EditorState extends State<Editor> {
 
     widget.composer.preferences.clearStyles();
 
-    if (widget.composer.selection == null || !widget.composer.selection!.isCollapsed) {
+    if (widget.composer.selection == null ||
+        !widget.composer.selection!.isCollapsed) {
       return;
     }
 
-    final node = widget.editor.document.getNodeById(widget.composer.selection!.extent.nodeId);
+    final node = widget.editor.document
+        .getNodeById(widget.composer.selection!.extent.nodeId);
     if (node is! TextNode) {
       return;
     }
 
-    final textPosition = widget.composer.selection!.extent.nodePosition as TextPosition;
+    final textPosition =
+        widget.composer.selection!.extent.nodePosition as TextPosition;
     if (textPosition.offset == 0) {
       return;
     }
@@ -223,6 +234,7 @@ class _EditorState extends State<Editor> {
         composer: widget.composer,
         getDocumentLayout: () => _docLayoutKey.currentState as DocumentLayout,
       ),
+      focusNode: widget.focusNode,
       keyboardActions: widget.keyboardActions,
       showDebugPaint: widget.showDebugPaint,
       document: ConstrainedBox(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,13 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.1.5"
   fake_async:
     dependency: transitive
     description:
@@ -155,7 +162,7 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   pedantic: ^1.9.2
 
-  uuid: ^3.0.1
+  uuid: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
In the Superlist application, we use a huge Focus tree for navigating users between components and pages. Because of that, the focus node in the library mostly loses the race condition and loses focus. This causes the following:
- User can not enter a text as the focus moves out of the Editor automatically
- The paragraphs can not be changed.
- In paragraph keyboard navigation stops working.
- When a user writes a text, it writes it to other focused areas with a cursor in the paragraph.

I tried to solve it with a Focus widget but it did not work as I expected it to be as well. 

With the provided focusNode, we can make the Editor part of our focus mechanism and, since the focusNode value is optional, we won't be breaking any current behavior.

-------------------------------------------------------------------------------------------
This fixes the following issues:

- In the Superlist app right now, we are using https://pub.dev/packages/stream_chat and it is using the uuid version 2.2.2. On the other hand, Super Editor uses 3.0.1, which is why it causes conflict.
- The Superlist app uses a lot of Focus nodes and Focusing mechanisms with keyboard shortcuts, that is why having a reference to FocusNode at the DocumentInteractor was necessary to make the RTE running for us.

